### PR TITLE
fix: problems

### DIFF
--- a/packages/umi-plugin-docz/src/doczrc.js
+++ b/packages/umi-plugin-docz/src/doczrc.js
@@ -19,6 +19,11 @@ export default {
   },
   modifyBundlerConfig: (config) => {
     const { resolve } = readFile('webpack');
+
+    // 依赖可能会被 hoist 到这里
+    config.resolve.modules.push(join(__dirname, '../node_modules'));
+    config.resolveLoader.modules.push(join(__dirname, '../node_modules'));
+
     return merge({ resolve }, config);
   },
   plugins: [

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -44,7 +44,7 @@ export default class Rollup {
           inputOptions = {
             ...this.inputOptions,
             // cjs and esm should external dependencies
-            external: this.inputOptions.external.concat(Object.keys(this.api.pkg.dependencies)),
+            external: this.inputOptions.external.concat(Object.keys(this.api.pkg.dependencies || {})),
           };
         } else {
           inputOptions = {


### PR DESCRIPTION

1. package.json 里可能不存在 dependencies，这样 Object.keys 会报错
2. docz 的依赖（比如 happypack）可能会被 hoist 到 umi-plugin-docz 下，本地 yarn 安装，然后 link 使用可复现

