### PR TITLE
Fix/regerator runtime not defined bug

### DIFF
--- a/packages/umi-plugin-docz/package.json
+++ b/packages/umi-plugin-docz/package.json
@@ -29,9 +29,7 @@
     "webpack-merge": "^4.1.5"
   },
   "devDependencies": {
-    "@babel/plugin-transform-runtime": "^7.2.0",
     "rollup": "^1.0.0",
-    "rollup-plugin-babel": "^4.2.0",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-cpy": "^1.1.0",
     "rollup-plugin-json": "^3.1.0",

--- a/packages/umi-plugin-docz/rollup.config.js
+++ b/packages/umi-plugin-docz/rollup.config.js
@@ -2,7 +2,6 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import json from 'rollup-plugin-json';
 import typescript from 'rollup-plugin-typescript2';
-import babel from 'rollup-plugin-babel';
 import copy from 'rollup-plugin-cpy';
 import pkg from './package.json'
 
@@ -21,13 +20,6 @@ const config = {
         }
     ],
     plugins: [
-      babel({
-        runtimeHelpers: true,
-        plugins: [
-          '@babel/plugin-transform-runtime'
-        ],
-        exclude: 'node_modules/**'
-      }),
       json(),
       nodeResolve(),
       commonjs(),

--- a/packages/umi-plugin-library/package.json
+++ b/packages/umi-plugin-library/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
-    "@babel/plugin-transform-runtime": "^7.2.0",
     "af-webpack": "1.3.0-beta.11",
     "autoprefixer": "^9.4.3",
     "babel-merge": "^2.0.1",

--- a/packages/umi-plugin-library/rollup.config.js
+++ b/packages/umi-plugin-library/rollup.config.js
@@ -2,7 +2,6 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import json from 'rollup-plugin-json';
 import typescript from 'rollup-plugin-typescript2';
-import babel from 'rollup-plugin-babel';
 import copy from 'rollup-plugin-cpy';
 import pkg from './package.json'
 
@@ -21,13 +20,6 @@ const config = {
         }
     ],
     plugins: [
-      babel({
-        runtimeHelpers: true,
-        plugins: [
-          '@babel/plugin-transform-runtime'
-        ],
-        exclude: 'node_modules/**'
-      }),
       json(),
       nodeResolve({
         preferBuiltins: true

--- a/packages/umi-plugin-library/src/build/babel/index.ts
+++ b/packages/umi-plugin-library/src/build/babel/index.ts
@@ -13,7 +13,7 @@ export default class Babel {
   private options: IBundleOptions;
 
   constructor(api: IApi, options: IBundleOptions) {
-    const { input = 'src/index.js' } = options;
+    const { entry: input = 'src/index.js' } = options;
     this.options = options;
     this.cwd = api.cwd || process.cwd();
     this.babel = resolveBin('@babel/cli', { executable: 'babel' });

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -70,7 +70,7 @@ export default class Rollup {
   private getOpts(options: IBundleOptions) {
     const { debug, pkg }: IApi = this.api;
     const {
-      input = 'src/index.js',
+      entry: input = 'src/index.js',
       cssModules = true,
       extraBabelPlugins = [],
       extraBabelPresets = [],

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -4,7 +4,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import json from 'rollup-plugin-json';
 import babel from 'rollup-plugin-babel';
 import postcss from 'rollup-plugin-postcss';
-import * as NpmImport from 'less-plugin-npm-import';
+import NpmImport from 'less-plugin-npm-import';
 import umiBabel from 'babel-preset-umi';
 import autoNamedExports from 'rollup-plugin-auto-named-exports';
 import peerExternal from 'rollup-plugin-peer-deps-external';

--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -39,7 +39,7 @@ export interface IBundleTypeOutput {
 }
 
 export interface IBundleOptions {
-  input?: string;
+  entry?: string;
   cssModules?: boolean;
   extraBabelPlugins?: BabelOpt[];
   extraBabelPresets?: BabelOpt[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "target": "es6",
+    "target": "es5",
     "lib": ["dom", "es7"]
   },
   "exclude": ["node_modules", "lib", "es"]


### PR DESCRIPTION
1. typescript 的 target 设为 es6, 会导致 umi build 执行出错，但为什么？
2. 修复 `import * as NpmInport` 不存在
3. 将 input 改为 entry. Close #24 