### PR TITLE
feat: #22 support build lerna package

### DIFF
--- a/packages/umi-plugin-library/src/build/babel/index.ts
+++ b/packages/umi-plugin-library/src/build/babel/index.ts
@@ -10,19 +10,16 @@ export default class Babel {
   private babel: string;
   private babelRc: string;
   private input: string;
-  private options: IBundleOptions;
 
-  constructor(api: IApi, options: IBundleOptions) {
-    const { entry: input = 'src/index.js' } = options;
-    this.options = options;
-    this.cwd = api.cwd || process.cwd();
+  constructor(api: IApi) {
+    this.cwd = api.cwd;
     this.babel = resolveBin('@babel/cli', { executable: 'babel' });
     this.babelRc = join(__dirname, 'babel.config');
-    this.input = dirname(join(this.cwd, input));
   }
 
-  public async build() {
-    const { cjs, esm } = this.options;
+  public async build(options: IBundleOptions) {
+    const { cjs, esm, entry: input = 'src/index.js' } = options;
+    this.input = dirname(join(this.cwd, input));
     const copy = new Copyfile(this.input, this.cwd);
     if (cjs && cjs.type === 'babel') {
       const dir = 'lib';

--- a/packages/umi-plugin-library/src/build/index.ts
+++ b/packages/umi-plugin-library/src/build/index.ts
@@ -1,6 +1,7 @@
 import rimraf from 'rimraf';
 import Rollup from './rollup';
 import Babel from './babel';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { IApi, IBundleOptions, IArgs } from '..';
 
@@ -10,30 +11,48 @@ class Bundler {
   private distFolder: string[];
   private api: IApi;
 
-  constructor(api: IApi, opts: IBundleOptions) {
+  constructor(api: IApi) {
     this.api = api;
-    this.bundlerRollup = new Rollup(api, opts);
-    this.bundlerBabel = new Babel(api, opts);
+    this.bundlerRollup = new Rollup(api);
+    this.bundlerBabel = new Babel(api);
     this.distFolder = ['dist', 'lib', 'es'];
   }
 
-  public async build() {
-    this.clean();
-    this.bundlerRollup.build();
-    this.bundlerBabel.build();
+  public async build(opts: IBundleOptions) {
+    const { cwd, pkg } = this.api;
+    this.clean(cwd);
+    this.bundlerRollup.build(opts, pkg, cwd);
+    this.bundlerBabel.build(opts);
   }
 
-  private clean() {
+  public async buildForLearna(opts: IBundleOptions) {
+    readdirSync(join(this.api.cwd, 'packages')).forEach(folder => {
+      const cwd = join(this.api.cwd, 'packages', folder);
+      const pkg = readFileSync(join(cwd, 'package.json'), 'utf-8');
+      if (pkg) {
+        this.clean(cwd);
+        this.bundlerRollup.build(opts, JSON.parse(pkg), cwd);
+      }
+    });
+
+    this.bundlerBabel.build(opts);
+  }
+
+  private clean(cwd: string) {
     this.distFolder.forEach(item => {
-      rimraf.sync(join(this.api.cwd, item));
+      rimraf.sync(join(cwd, item));
     });
   }
 }
 
 export default (api: IApi, opts: IBundleOptions, args: IArgs) => {
   const subCommand = args._[0];
+  const bundler = new Bundler(api);
   if (subCommand === 'build') {
-    const bundler = new Bundler(api, opts);
-    bundler.build();
+    if (opts.learna) {
+      bundler.buildForLearna(opts);
+    } else {
+      bundler.build(opts);
+    }
   }
 };

--- a/packages/umi-plugin-library/src/build/index.ts
+++ b/packages/umi-plugin-library/src/build/index.ts
@@ -1,7 +1,7 @@
 import rimraf from 'rimraf';
 import Rollup from './rollup';
 import Babel from './babel';
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { IApi, IBundleOptions, IArgs } from '..';
 
@@ -25,7 +25,7 @@ class Bundler {
     this.bundlerBabel.build(opts);
   }
 
-  public async buildForLearna(opts: IBundleOptions) {
+  public async buildForLerna(opts: IBundleOptions) {
     readdirSync(join(this.api.cwd, 'packages')).forEach(folder => {
       const cwd = join(this.api.cwd, 'packages', folder);
       const pkg = readFileSync(join(cwd, 'package.json'), 'utf-8');
@@ -49,8 +49,9 @@ export default (api: IApi, opts: IBundleOptions, args: IArgs) => {
   const subCommand = args._[0];
   const bundler = new Bundler(api);
   if (subCommand === 'build') {
-    if (opts.learna) {
-      bundler.buildForLearna(opts);
+    const useLerna = existsSync(join(api.cwd, 'lerna.json'));
+    if (useLerna) {
+      bundler.buildForLerna(opts);
     } else {
       bundler.build(opts);
     }

--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -46,7 +46,6 @@ export interface IBundleTypeOutput {
 
 export interface IBundleOptions {
   entry?: string;
-  learna?: boolean;
   cssModules?: boolean;
   extraBabelPlugins?: BabelOpt[];
   extraBabelPresets?: BabelOpt[];

--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -8,23 +8,26 @@ export interface IArgs {
     [index: number]: Params;
   };
 }
+
+export interface IPkg {
+  name: string;
+  main?: string;
+  module?: string;
+  unpkg?: string;
+  dependencies: IStringObject;
+}
+
 export interface IApi {
   applyPlugins: (name: string, options: object) => object;
   cwd: string;
   registerCommand: (name: string, options: object, callback: (args: IArgs) => void) => void;
   webpackConfig: {
     resolve: {
-      alias: IStringObject
-    }
+      alias: IStringObject;
+    };
   };
   debug: (msg: any) => void;
-  pkg: {
-    name: string;
-    main?: string;
-    module?: string;
-    unpkg?: string;
-    dependencies: IStringObject;
-  };
+  pkg: IPkg;
 }
 
 export interface IOpts extends IBundleOptions {
@@ -37,11 +40,13 @@ export type BundleTool = 'rollup' | 'babel';
 
 export interface IBundleTypeOutput {
   type: BundleTool;
+  name?: string;
   dir?: string;
 }
 
 export interface IBundleOptions {
   entry?: string;
+  learna?: boolean;
   cssModules?: boolean;
   extraBabelPlugins?: BabelOpt[];
   extraBabelPresets?: BabelOpt[];


### PR DESCRIPTION
1. 支持了 lerna 这种分包管理项目。实现原理是: 获取 `packages` 目录，分别使用 `rollup` 打包并生产产物到各自目录, 配置参数我使用了 lerna，后面更多配置可以为 object，或者不加字段，用 `entry` 是否目录来识别，云谦的意见呢?
2. 使用祯逸的项目进行测试，他的项目是纯 library 库，并非组件库，目前已尝试最小的改动引入 `bigfish`，可以顺利打包并生成文档，下一步再继续对接他的库测试，完善 `umi-plugin-library`。