### PR TITLE
fix: umd bundle same size

### DIFF
--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -51,6 +51,12 @@ export interface IBundleTypeOutput {
   dir?: string;
 }
 
+export interface IUmd {
+  globals?: IStringObject;
+  name?: string;
+  file?: string;
+}
+
 export interface IBundleOptions {
   entry?: string;
   cssModules?: boolean;
@@ -60,19 +66,13 @@ export interface IBundleOptions {
   namedExports?: IStringObject;
   esm?: IBundleTypeOutput | false;
   cjs?: IBundleTypeOutput | false;
+  umd?: IUmd | false;
   targets?:
     | string
     | string[]
     | {
         [prop: string]: string;
       };
-  umd?:
-    | {
-        globals?: IStringObject;
-        name?: string;
-        file?: string;
-      }
-    | false;
   external?: string[];
 }
 


### PR DESCRIPTION
1. 这里的异步写法会导致最终生成的 umd 产物都一样大小.
2. 调整 build 成功文案.