### PR TITLE
Feat/support docz argv

### DIFF
--- a/packages/umi-plugin-docz/src/index.ts
+++ b/packages/umi-plugin-docz/src/index.ts
@@ -9,7 +9,6 @@ export interface IOpts {
   wrapper?: string;
   typescript?: string;
   indexHtml?: string;
-  host?: string;
 }
 
 type Params = 'build' | 'dev' | 'deploy';
@@ -76,13 +75,12 @@ class Docz {
   }
 
   private getCommonOptions(opts: IOpts = {}) {
-    const { theme, wrapper, typescript, indexHtml, host } = opts;
+    const { theme, wrapper, typescript, indexHtml } = opts;
     return [
       ...(typescript ? ['--typescript', typescript] : []),
       ...(theme ? ['--theme', theme] : []),
       ...(wrapper ? ['--wrapper', wrapper] : []),
       ...(indexHtml ? ['--indexHtml', indexHtml] : []),
-      ...(host ? ['--host', host] : []),
     ];
   }
 

--- a/packages/umi-plugin-docz/src/index.ts
+++ b/packages/umi-plugin-docz/src/index.ts
@@ -9,6 +9,7 @@ export interface IOpts {
   wrapper?: string;
   typescript?: string;
   indexHtml?: string;
+  host?: string;
 }
 
 type Params = 'build' | 'dev' | 'deploy';
@@ -47,6 +48,7 @@ class Docz {
       '--port',
       '8001',
       ...comnonOpts,
+      ...process.argv.slice(4),
     ]);
 
     this.onEvent(child);
@@ -61,6 +63,7 @@ class Docz {
       '--base',
       '.',
       ...comnonOpts,
+      ...process.argv.slice(4),
     ]);
     this.onEvent(child);
   }
@@ -73,12 +76,13 @@ class Docz {
   }
 
   private getCommonOptions(opts: IOpts = {}) {
-    const { theme, wrapper, typescript, indexHtml } = opts;
+    const { theme, wrapper, typescript, indexHtml, host } = opts;
     return [
       ...(typescript ? ['--typescript', typescript] : []),
       ...(theme ? ['--theme', theme] : []),
       ...(wrapper ? ['--wrapper', wrapper] : []),
       ...(indexHtml ? ['--indexHtml', indexHtml] : []),
+      ...(host ? ['--host', host] : []),
     ];
   }
 


### PR DESCRIPTION
1. 支持传入 docz 参数，如`umi doc dev --host haha.alipay.net`. 修复如果设置本地 host，没有设置 webpack devserver host 会报 `Invalid Host header`