### PR TITLE
Feat/support config global cssmodules

### DIFF
--- a/.umirc.js
+++ b/.umirc.js
@@ -1,3 +1,5 @@
+const icon = `https://avatars2.githubusercontent.com/u/33895495?s=48&v=4`;
+
 export default {
   plugins: [
     [
@@ -7,9 +9,10 @@ export default {
           base: "/umi-plugin-library",
           files: "docs/**/*.mdx",
           hashRouter: true,
+          favicon: icon,
           themeConfig: {
             logo: {
-              src: `https://avatars2.githubusercontent.com/u/33895495?s=48&v=4`,
+              src: icon,
               width: 48,
             },
           }

--- a/.umirc.js
+++ b/.umirc.js
@@ -6,7 +6,13 @@ export default {
           title: "Umi 组件开发工具",
           base: "/umi-plugin-library",
           files: "docs/**/*.mdx",
-          hashRouter: true
+          hashRouter: true,
+          themeConfig: {
+            logo: {
+              src: `https://avatars2.githubusercontent.com/u/33895495?s=48&v=4`,
+              width: 48,
+            },
+          }
         }
       }
     ]

--- a/docs/api/1-index.mdx
+++ b/docs/api/1-index.mdx
@@ -2,7 +2,6 @@
 name: 说明
 route: /api
 menu: API
-order: 10
 ---
 # API 说明
 

--- a/docs/api/2-doc.mdx
+++ b/docs/api/2-doc.mdx
@@ -2,7 +2,6 @@
 name: doc 配置
 route: /api/doc
 menu: API
-order: 9
 ---
 # doc 配置
 

--- a/docs/api/3-bundle.mdx
+++ b/docs/api/3-bundle.mdx
@@ -2,7 +2,6 @@
 name: bundle 配置
 route: /api/bundle
 menu: API
-order: 8
 ---
 # bundle 配置
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "lint": "tslint -p tsconfig.json",
     "precommit": "lint-staged",
     "dev": "umi doc dev",
-    "build:doc": "umi doc build",
-    "deploy:doc": "umi doc deploy",
-    "publish:doc": "yarn run build:doc && yarn run deploy:doc"
+    "publish:doc": "umi doc build && umi doc deploy"
   },
   "lint-staged": {
     "*.ts": [

--- a/packages/umi-plugin-docz/src/doczrc.js
+++ b/packages/umi-plugin-docz/src/doczrc.js
@@ -139,7 +139,25 @@ const defaultThemeConfig = {
 }
 
 const customOpions = readFile('docOpts');
-const { themeConfig: customThemeConfig = {}} = customOpions;
+const { themeConfig: customThemeConfig = {}, style = [], script = [], favicon, camelCase } = customOpions;
+
+const cssOpts = {
+  camelCase
+};
+
+// external js and css
+const htmlContext = {
+  favicon,
+  head: {
+    links: style.map(item => ({
+      rel: 'stylesheet',
+      href: item
+    })),
+    scripts: script.map(item => ({
+      src: item
+    }))
+  }
+}
 
 // use umi runtime webpack config
 export default {
@@ -177,6 +195,7 @@ export default {
       loaderOpts: {
         javascriptEnabled: true,
       },
+      cssOpts
     }),
     css({
       preprocessor: 'postcss',
@@ -190,8 +209,10 @@ export default {
       cssmodules: true,
       ruleOpts: {
         exclude: /global\.css$/
-      }
+      },
+      cssOpts
   }),
   ],
-  themeConfig: deepmerge(defaultThemeConfig, customThemeConfig)
+  themeConfig: deepmerge(defaultThemeConfig, customThemeConfig),
+  htmlContext
 };

--- a/packages/umi-plugin-docz/src/doczrc.js
+++ b/packages/umi-plugin-docz/src/doczrc.js
@@ -32,10 +32,10 @@ const defaultThemeConfig = {
   /**
    * Logo
    */
-  logo: {
-    src: `https://avatars2.githubusercontent.com/u/33895495?s=48&v=4`,
-    width: 48,
-  },
+  // logo: {
+  //   src: `https://avatars2.githubusercontent.com/u/33895495?s=48&v=4`,
+  //   width: 48,
+  // },
   /**
    * Radius
    */

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -70,11 +70,9 @@ export default class Rollup {
     const { debug, webpackConfig = { resolve: { alias: {} } } }: IApi = this.api;
     const {
       entry: input = 'src/index.js',
-      cssModules = true,
       extraBabelPlugins = [],
       extraBabelPresets = [],
       namedExports,
-      extraPostCSSPlugins = [],
       targets = {
         ie: 11,
       },
@@ -92,19 +90,7 @@ export default class Rollup {
           ...webpackAlias,
           resolve: ['.js', '/index.js'],
         }),
-        postcss({
-          modules: cssModules,
-          use: [
-            [
-              'less',
-              {
-                plugins: [new NpmImport({ prefix: '~' })],
-                javascriptEnabled: true,
-              },
-            ],
-          ],
-          plugins: [autoprefixer, ...extraPostCSSPlugins],
-        }),
+        this.pluinPostcss(options),
         babel({
           runtimeHelpers: true,
           presets: [
@@ -201,5 +187,30 @@ export default class Rollup {
         result[newKey] = webpackAlias[key];
       });
     return result;
+  }
+
+  private pluinPostcss(options: IBundleOptions) {
+    const { extraPostCSSPlugins = [] } = options;
+    let cssModules = options.cssModules;
+    if (cssModules !== false) {
+      cssModules = {
+        ...(typeof cssModules === 'object' && cssModules),
+        globalModulePaths: [/global\.less$/, /global\.css$/],
+      };
+    }
+
+    return postcss({
+      modules: cssModules,
+      use: [
+        [
+          'less',
+          {
+            plugins: [new NpmImport({ prefix: '~' })],
+            javascriptEnabled: true,
+          },
+        ],
+      ],
+      plugins: [autoprefixer, ...extraPostCSSPlugins],
+    });
   }
 }

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -134,6 +134,9 @@ export default class Rollup {
           return;
         }
         debug(warning);
+        if (warning.code === 'UNRESOLVED_IMPORT') {
+          this.api.log.warn(warning.message);
+        }
       },
       external: external.concat(['react', 'react-dom', 'antd']),
     };

--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -58,9 +58,14 @@ export interface IUmd {
   file?: string;
 }
 
+export interface ICssModules {
+  camelCase?: boolean;
+  globalModulePaths?: RegExp[];
+}
+
 export interface IBundleOptions {
   entry?: string;
-  cssModules?: boolean;
+  cssModules?: boolean | ICssModules;
   extraBabelPlugins?: BabelOpt[];
   extraBabelPresets?: BabelOpt[];
   extraPostCSSPlugins?: any[];

--- a/packages/umi-plugin-library/src/index.ts
+++ b/packages/umi-plugin-library/src/index.ts
@@ -88,7 +88,10 @@ export interface IStringObject {
 
 export default function(api: IApi, opts: IOpts = {}) {
   // register docz plugin
-  doczPlugin(api, opts.doc);
+  doczPlugin(api, {
+    ...opts.doc,
+    camelCase: typeof opts.cssModules === 'object' && opts.cssModules.camelCase,
+  });
   api.registerCommand(
     'lib',
     {


### PR DESCRIPTION
1. 让 build 时也支持 exclude css modules, babel 还暂未支持。
2. 如果缺少依赖警告
3. 去掉默认的 umi logo，显示 name
4. 支持了引入外部资源，设置 favicon, 支持 #53  的 camelCase