### PR TITLE
fix: remove bigfish alias compatible

### DIFF
--- a/packages/umi-plugin-library/package.json
+++ b/packages/umi-plugin-library/package.json
@@ -39,7 +39,6 @@
     "resolve-bin": "^0.4.0",
     "rimraf": "^2.6.2",
     "rollup": "^1.0.0",
-    "rollup-plugin-alias": "^1.5.1",
     "rollup-plugin-auto-named-exports": "^1.0.0-beta.1",
     "rollup-plugin-babel": "^4.2.0",
     "rollup-plugin-commonjs": "^9.2.0",

--- a/packages/umi-plugin-library/src/build/rollup.ts
+++ b/packages/umi-plugin-library/src/build/rollup.ts
@@ -6,7 +6,6 @@ import babel from 'rollup-plugin-babel';
 import postcss from 'rollup-plugin-postcss';
 import NpmImport from 'less-plugin-npm-import';
 import umiBabel from 'babel-preset-umi';
-import alias from 'rollup-plugin-alias';
 import autoNamedExports from 'rollup-plugin-auto-named-exports';
 import peerExternal from 'rollup-plugin-peer-deps-external';
 import typescriptPlugin from 'rollup-plugin-typescript2';
@@ -14,7 +13,7 @@ import { terser } from 'rollup-plugin-terser';
 import autoprefixer from 'autoprefixer';
 import camelCase from 'camelcase';
 import copyPlugin from 'rollup-plugin-cpy';
-import { IApi, IBundleOptions, IStringObject, IPkg, IUmd } from '..';
+import { IApi, IBundleOptions, IPkg, IUmd } from '..';
 import { join, basename } from 'path';
 
 const EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx', '.es6', '.es', '.mjs'];
@@ -89,7 +88,7 @@ export default class Rollup {
   }
 
   private getOpts(options: IBundleOptions, pkg: IPkg, cwd: string) {
-    const { debug, webpackConfig = { resolve: { alias: {} } } }: IApi = this.api;
+    const { debug }: IApi = this.api;
     const {
       entry: input = 'src/index',
       cjs,
@@ -101,15 +100,10 @@ export default class Rollup {
       treeshake = { propertyReadSideEffects: false },
       sourcemap = false,
     } = options;
-    const webpackAlias = this.transformAlias(webpackConfig.resolve.alias);
     this.inputOptions = {
       input: join(cwd, input),
       plugins: [
         peerExternal(),
-        alias({
-          ...webpackAlias,
-          resolve: ['.js', '/index.js'],
-        }),
         this.pluinPostcss(options),
         ...(typescript ? [this.pluginTypescript(options, cwd)] : []),
         this.pluginBabel(options),
@@ -181,18 +175,6 @@ export default class Rollup {
       sourcemap,
       development,
     };
-  }
-
-  // remove the tail $ symbol
-  private transformAlias(webpackAlias: IStringObject): IStringObject {
-    const result: IStringObject = {};
-    Object.keys(webpackAlias)
-      .reverse()
-      .forEach(key => {
-        const newKey = key.replace(/\$$/, '');
-        result[newKey] = webpackAlias[key];
-      });
-    return result;
   }
 
   private pluinPostcss(options: IBundleOptions) {

--- a/packages/umi-plugin-library/src/typed.d.ts
+++ b/packages/umi-plugin-library/src/typed.d.ts
@@ -13,5 +13,4 @@ declare module 'fs-extra';
 declare module 'glob';
 declare module 'rimraf';
 declare module 'rollup-plugin-terser';
-declare module 'rollup-plugin-alias';
 declare module 'rollup-plugin-cpy';


### PR DESCRIPTION
1. 移除 bigfish alias 兼容逻辑，因为不能让组件依赖框架，不支持使用框架内 api