### PR TITLE
fix: cannot read property 'inherits' of undefined

### DIFF
--- a/packages/umi-plugin-library/package.json
+++ b/packages/umi-plugin-library/package.json
@@ -37,6 +37,7 @@
     "less": "^3.9.0",
     "less-plugin-npm-import": "^2.1.0",
     "resolve-bin": "^0.4.0",
+    "rimraf": "^2.6.2",
     "rollup": "^1.0.0",
     "rollup-plugin-auto-named-exports": "^1.0.0-beta.1",
     "rollup-plugin-babel": "^4.2.0",


### PR DESCRIPTION
1. 不能将 `rimraf` 从依赖中删除，删除后会将 `rimraf ` 打包进代码，生成的产物会出现 [Cannot read property 'inherits' of undefined](http://gitlab.alipay-inc.com/bigfish/bigfish/builds/1514048) 这是另外一个问题