### PR TITLE
fix(docz): build a bundle no need to use webpackHotDevClient.js

### DIFF
--- a/packages/umi-plugin-docz/src/doczrc.js
+++ b/packages/umi-plugin-docz/src/doczrc.js
@@ -13,8 +13,15 @@ function readFile(name) {
   return JSON.parse(config);
 }
 
+function findAndRemove(arr, str) {
+  const found = arr.find(item => item.indexOf(str) !== -1);
+  if(found) {
+    arr.splice(arr.indexOf(found), 1);
+  }
+}
+
 const customOpions = readFile('docOpts');
-const { themeConfig: customThemeConfig = {}, style = [], script = [], favicon, cssModules, ...rest } = customOpions;
+const { themeConfig: customThemeConfig = {}, style = [], script = [], favicon, cssModules, subCommand, ...rest } = customOpions;
 
 // external js and css
 const htmlContext = {
@@ -50,6 +57,11 @@ export default {
     // 依赖可能会被 hoist 到这里
     config.resolve.modules.push(join(__dirname, '../node_modules'));
     config.resolveLoader.modules.push(join(__dirname, '../node_modules'));
+
+    // build 不需要 webpackHotDevClient
+    if(subCommand === 'build' && config.entry.app) {
+      findAndRemove(config.entry.app, 'webpackHotDevClient.js');
+    }
 
     return merge({ resolve }, config);
   },

--- a/packages/umi-plugin-docz/src/index.ts
+++ b/packages/umi-plugin-docz/src/index.ts
@@ -79,14 +79,15 @@ export default function(api: IApi, opts: IOpts = {}) {
     },
     (args: IArgs) => {
       getWebpackConfig(api);
+      const subCommand = args._[0];
       // write doc options to file for further use
       writeFile('docOpts', {
         ...opts,
         base: opts.base || `/${api.pkg.name}`,
         port: opts.port || '8001',
+        subCommand,
       });
 
-      const subCommand = args._[0];
       const docz = new Docz(api);
       if (subCommand === 'dev' || subCommand === 'build') {
         docz.devOrBuild(subCommand);


### PR DESCRIPTION
1. docz build 时去掉 webpackHotDevClient.js, 避免打包产物会去建立 websocket 404报错

![image](https://user-images.githubusercontent.com/4002237/52857388-feec5280-3161-11e9-990e-6f1e9e97abe5.png)
