### PR TITLE
fix: babel complied bundle has absoulute path

### DIFF
--- a/packages/umi-plugin-library/src/build/babel/babel.config.js
+++ b/packages/umi-plugin-library/src/build/babel/babel.config.js
@@ -1,7 +1,9 @@
 // config file not ues ts
 const { join } = require('path');
 const babelMerge = require('babel-merge');
-const umiBabelConfig = require('babel-preset-umi').default();
+
+// 需要传入一个空对象，相关代码 https://github.com/umijs/umi/blob/master/packages/babel-preset-umi/src/index.js#L15
+const umiBabelConfig = require('babel-preset-umi').default(undefined, {transformRuntime: {}});
 
 /**
  * 获取 css 插件


### PR DESCRIPTION
1. 测试 antd-cloud 发现产物中包含绝对路径，和 babel-preset-umi 最近 feature 有关，需要传入一个空对象，绕过问题。