### PR TITLE
lock @babel/preset-env

### DIFF
--- a/packages/umi-plugin-library/package.json
+++ b/packages/umi-plugin-library/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@babel/cli": "^7.2.3",
-    "@babel/preset-env": "^7.2.3",
+    "@babel/preset-env": "7.3.1",
     "@types/css-modules": "^1.0.0",
     "autoprefixer": "^9.4.3",
     "babel-merge": "^2.0.1",


### PR DESCRIPTION
@babel/preset-env 的 7.4.1 会依赖到 core-js 的 3.0，在一些包管理工具下会使得 core-js 被提到最上面，导致  umi 报错。

锁定版本，保持和 umi 一直。

后续推荐使用 umi-library，该包会逐步废弃掉。